### PR TITLE
Update README and mapping for process_creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SigmaToSecuronix
-A simple tool for converting Sigma detection rules to Securonix Spotter queries.
+A simple tool for converting Sigma detection rules to Securonix Snypr Spotter queries.
 
 ## Prerequisites
 
@@ -16,6 +16,7 @@ pip install securonix-cli
 ```
 git clone https://github.com/Securonix/SigmaToSecuronix
 cd SigmaToSecuronix
+poetry install && poetry shell
 securonix-cli convert --mapping config/mapping.yml input_file.yml
 ```
 

--- a/config/mapping.yml
+++ b/config/mapping.yml
@@ -221,6 +221,7 @@ logsources:
       rg_functionality:
         - "Endpoint Management Systems"
       Operation:
+        - ProcessCreate
         - Process Create
         - "Process Create (rule: ProcessCreate)"
         - ProcessRollup2


### PR DESCRIPTION
Slight tweaks to the README to include instructions for utilizing Poetry shell as a virtualenv as the project utilizes it. This makes it simpler for developers to get up and running with it should they choose to do so.

Additionally added a slight tweak to the `process_creation` mapping section as many clients with Sysmon may parse out the specific rule name, which in this case is `ProcessCreate`.