### PR TITLE
Update mapping.yaml for common Windows operations

### DIFF
--- a/config/mapping.yml
+++ b/config/mapping.yml
@@ -26,7 +26,9 @@ logsources:
     product: windows
     conditions:
       rg_functionality: "Endpoint Management Systems"
-      Operation: "Dns query"
+      Operation:
+        - "DnsQuery"
+        - "Dns query"
     rewrite:
       service: sysmon
   pipe_created:
@@ -125,6 +127,7 @@ logsources:
       rg_functionality:
         - "Endpoint Management Systems"
       Operation:
+        - "NetworkConnect"
         - "Network connection detected"
         - "Network connection detected (rule: NetworkConnect)"
   process_access:
@@ -143,6 +146,7 @@ logsources:
       rg_functionality:
         - "Endpoint Management Systems"
       Operation:
+        - FileCreate
         - "File created"
         - "File created (rule: FileCreate)"
   file_delete:
@@ -221,6 +225,7 @@ logsources:
       rg_functionality:
         - "Endpoint Management Systems"
       Operation:
+        - ProcessCreate
         - Process Create
         - "Process Create (rule: ProcessCreate)"
         - ProcessRollup2


### PR DESCRIPTION
Updates to various Windows operations in the `config/mapping.yml`, including a duplicate of the change made in [PR #1](https://github.com/Securonix/SigmaToSecuronix/pull/1) for the `process_creation` events.

Depending on the parsing that clients use the `deviceAction` can be parsed out as the rule name, so this config change (FileCreate, DnsQuery, etc.) allows for those options to
exist in the generated Snypr queries.

These could later be extended to filter for `deviceEventCategory` which more accurately encompass these events.